### PR TITLE
ci: add PR preview workflow

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,248 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+permissions:
+  contents: read
+  pull-requests: write
+  deployments: write
+
+concurrency:
+  group: pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR code
+        uses: actions/checkout@v6
+
+      - name: Create deployment
+        id: deployment
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { data: deployment } = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.payload.pull_request.head.sha,
+              environment: `landing-${context.payload.pull_request.number}`,
+              auto_merge: false,
+              required_contexts: [],
+              transient_environment: true,
+              production_environment: false,
+              description: `Preview for PR #${context.payload.pull_request.number}`,
+            });
+            core.setOutput('id', deployment.id);
+
+      - name: Set deployment status to in_progress
+        uses: actions/github-script@v8
+        with:
+          script: |
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: ${{ steps.deployment.outputs.id }},
+              state: 'in_progress',
+              log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });
+
+      - name: Deploy preview to staging repo
+        env:
+          STAGING_TOKEN: ${{ secrets.STAGING_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euxo pipefail
+
+          if [ -z "${STAGING_TOKEN}" ]; then
+            echo "::warning::STAGING_TOKEN is not set. Skipping preview deployment. Add the secret in repository settings."
+            exit 0
+          fi
+
+          PREVIEW_DIR="landing-${PR_NUMBER}"
+          STAGING_DIR="/tmp/staging-${PR_NUMBER}"
+
+          rm -rf "${STAGING_DIR}"
+          git clone --depth 1 "https://x-access-token:${STAGING_TOKEN}@github.com/reparteix/staging.git" "${STAGING_DIR}"
+
+          rm -rf "${STAGING_DIR}/${PREVIEW_DIR}"
+          mkdir -p "${STAGING_DIR}/${PREVIEW_DIR}"
+
+          rsync -a \
+            --exclude '.git/' \
+            --exclude '.github/' \
+            --exclude '.gitignore' \
+            --exclude 'README.md' \
+            ./ "${STAGING_DIR}/${PREVIEW_DIR}/"
+
+          touch "${STAGING_DIR}/.nojekyll"
+
+          cd "${STAGING_DIR}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "deploy: update landing preview for PR #${PR_NUMBER}"
+            git push origin main
+          fi
+
+      - name: Set deployment status to success
+        if: success()
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const previewUrl = `https://staging.reparteix.cat/landing-${prNumber}/`;
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: ${{ steps.deployment.outputs.id }},
+              state: 'success',
+              environment_url: previewUrl,
+              log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });
+
+      - name: Set deployment status to failure
+        if: failure()
+        uses: actions/github-script@v8
+        with:
+          script: |
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: ${{ steps.deployment.outputs.id }},
+              state: 'failure',
+              log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });
+
+      - name: Comment on PR with preview URL
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const previewUrl = `https://staging.reparteix.cat/landing-${prNumber}/`;
+            const marker = '<!-- pr-preview-comment -->';
+            const fullBody = `${marker}\n🚀 **Preview deployed!**\n\n${previewUrl}`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const existing = comments.find(c => c.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: fullBody,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: fullBody,
+              });
+            }
+
+  cleanup-preview:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove preview from staging repo
+        env:
+          STAGING_TOKEN: ${{ secrets.STAGING_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euxo pipefail
+
+          if [ -z "${STAGING_TOKEN}" ]; then
+            echo "::warning::STAGING_TOKEN is not set. Skipping preview cleanup. Add the secret in repository settings."
+            exit 0
+          fi
+
+          PREVIEW_DIR="landing-${PR_NUMBER}"
+          STAGING_DIR="/tmp/staging-${PR_NUMBER}"
+          rm -rf "${STAGING_DIR}"
+          git clone --depth 1 "https://x-access-token:${STAGING_TOKEN}@github.com/reparteix/staging.git" "${STAGING_DIR}"
+
+          if [ -d "${STAGING_DIR}/${PREVIEW_DIR}" ]; then
+            rm -rf "${STAGING_DIR}/${PREVIEW_DIR}"
+            cd "${STAGING_DIR}"
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add -A
+            if git diff --cached --quiet; then
+              echo "No changes to commit"
+            else
+              git commit -m "cleanup: remove landing preview for PR #${PR_NUMBER}"
+              git push origin main
+            fi
+          else
+            echo "Preview directory ${PREVIEW_DIR} does not exist, nothing to clean up"
+          fi
+
+      - name: Deactivate deployment
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const environment = `landing-${prNumber}`;
+
+            const { data: deployments } = await github.rest.repos.listDeployments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              environment,
+              per_page: 100,
+            });
+
+            for (const deployment of deployments) {
+              await github.rest.repos.createDeploymentStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                deployment_id: deployment.id,
+                state: 'inactive',
+              });
+            }
+
+      - name: Update PR comment
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const wasMerged = context.payload.pull_request.merged;
+            const marker = '<!-- pr-preview-comment -->';
+            const body = `${marker}\n🗑️ **Preview removed.** (PR ${wasMerged ? 'merged' : 'closed without merge'})`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const existing = comments.find(c => c.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
   <!-- SEO -->
-  <title>Reparteix – Reparteix despeses amb sync privat, recordatoris i sense comptes</title>
+  <title>Reparteix – Despeses compartides amb sync privat i sense comptes</title>
   <meta name="description" content="Reparteix és l'alternativa local-first a Splitwise. Gestiona despeses compartides, funciona offline, permet compartir recordatoris de pagament i sincronitza entre dispositius amb xifrat punt a punt, sense registre." />
   <link rel="canonical" href="https://reparteix.cat/" />
   <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
@@ -15,7 +15,7 @@
   <meta property="og:url" content="https://reparteix.cat/" />
   <meta property="og:site_name" content="Reparteix" />
   <meta property="og:locale" content="ca_ES" />
-  <meta property="og:title" content="Reparteix – Despeses compartides amb sync privat, recordatoris i sense comptes" />
+  <meta property="og:title" content="Reparteix – Despeses compartides amb sync privat i sense comptes" />
   <meta property="og:description" content="Alternativa local-first a Splitwise. Offline, privada, instal·lable, amb recordatoris compartibles i sincronització P2P xifrada." />
   <meta property="og:image" content="https://reparteix.cat/og-image.png" />
   <meta property="og:image:width" content="1200" />

--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
   <!-- SEO -->
-  <title>Reparteix – Reparteix despeses amb sync privat, sense comptes ni núvol</title>
-  <meta name="description" content="Reparteix és l'alternativa local-first a Splitwise. Gestiona despeses compartides, funciona offline i ara sincronitza entre dispositius amb xifrat punt a punt, sense registre." />
+  <title>Reparteix – Reparteix despeses amb sync privat, recordatoris i sense comptes</title>
+  <meta name="description" content="Reparteix és l'alternativa local-first a Splitwise. Gestiona despeses compartides, funciona offline, permet compartir recordatoris de pagament i sincronitza entre dispositius amb xifrat punt a punt, sense registre." />
   <link rel="canonical" href="https://reparteix.cat/" />
   <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
 
@@ -15,8 +15,8 @@
   <meta property="og:url" content="https://reparteix.cat/" />
   <meta property="og:site_name" content="Reparteix" />
   <meta property="og:locale" content="ca_ES" />
-  <meta property="og:title" content="Reparteix – Despeses compartides amb sync privat i sense comptes" />
-  <meta property="og:description" content="Alternativa local-first a Splitwise. Offline, privada, instal·lable i amb sincronització P2P xifrada entre dispositius." />
+  <meta property="og:title" content="Reparteix – Despeses compartides amb sync privat, recordatoris i sense comptes" />
+  <meta property="og:description" content="Alternativa local-first a Splitwise. Offline, privada, instal·lable, amb recordatoris compartibles i sincronització P2P xifrada." />
   <meta property="og:image" content="https://reparteix.cat/og-image.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -24,8 +24,8 @@
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Reparteix – Despeses compartides amb sync privat" />
-  <meta name="twitter:description" content="Alternativa local-first a Splitwise. Offline, privada, instal·lable i amb sincronització P2P xifrada." />
+  <meta name="twitter:title" content="Reparteix – Despeses compartides amb sync privat i recordatoris" />
+  <meta name="twitter:description" content="Alternativa local-first a Splitwise. Offline, privada, instal·lable, amb recordatoris compartibles i sincronització P2P xifrada." />
   <meta name="twitter:image" content="https://reparteix.cat/og-image.png" />
   <meta name="twitter:image:alt" content="Reparteix – App per gestionar despeses compartides" />
 
@@ -36,7 +36,7 @@
     "@type": "WebApplication",
     "name": "Reparteix",
     "url": "https://app.reparteix.cat/",
-    "description": "Reparteix és l'alternativa local-first a Splitwise. Gestiona despeses compartides, funciona offline, no requereix registre i permet sincronització punt a punt xifrada entre dispositius.",
+    "description": "Reparteix és l'alternativa local-first a Splitwise. Gestiona despeses compartides, funciona offline, no requereix registre, permet compartir recordatoris de pagament i sincronització punt a punt xifrada entre dispositius.",
     "applicationCategory": "FinanceApplication",
     "operatingSystem": "Any",
     "offers": {
@@ -51,6 +51,7 @@
       "Instal·lable com a PWA",
       "Compartir grups per enllaç",
       "Sincronització P2P xifrada entre dispositius",
+      "Recordatoris de pagament compartibles",
       "Exportació i importació JSON",
       "Càlcul automàtic de deutes mínims"
     ],
@@ -1062,12 +1063,12 @@
         </div>
 
         <h1 class="hero__title">
-          Reparteix despeses compartides <em>amb sync privat i sense comptes</em>
+          Reparteix despeses compartides <em>amb sync privat, recordatoris i sense comptes</em>
         </h1>
 
         <p class="hero__subtitle">
-          Per a viatges, pisos i grups. Funciona offline, guarda les dades al teu dispositiu
-          i ara permet sincronitzar entre mòbils o ordinadors amb xifrat punt a punt.
+          Per a viatges, pisos i grups. Funciona offline, guarda les dades al teu dispositiu,
+          et deixa compartir recordatoris de pagament i sincronitza entre mòbils o ordinadors amb xifrat punt a punt.
         </p>
 
         <div class="hero__ctas">
@@ -1258,11 +1259,20 @@
       </article>
 
       <article class="feature-card" role="listitem">
+        <div class="feature-card__icon" aria-hidden="true">📤</div>
+        <h3 class="feature-card__title">Compartir recordatoris de pagament</h3>
+        <p class="feature-card__desc">
+          Des de les transferències suggerides pots enviar un missatge preparat perquè qui deu diners
+          sàpiga exactament quant ha de pagar i a qui.
+        </p>
+      </article>
+
+      <article class="feature-card" role="listitem">
         <div class="feature-card__icon" aria-hidden="true">🔐</div>
         <h3 class="feature-card__title">Sync P2P xifrat</h3>
         <p class="feature-card__desc">
           Sincronitza un grup entre dos dispositius en temps real amb WebRTC i xifrat AES-GCM.
-          Sense compte, sense backend propi i amb contrasenya de grup.
+          Sense compte, sense backend propi, amb contrasenya de grup i amb millor gestió de grups grans.
         </p>
       </article>
 
@@ -1348,7 +1358,7 @@
           <h3 class="step__title">Sincronitza o liquida</h3>
           <p class="step__desc">
             Quan vulguis continuar en un altre dispositiu o compartir l'estat del grup,
-            fas un sync xifrat. I l'app et continua dient qui ha de pagar a qui.
+            fas un sync xifrat o comparteixes un recordatori de pagament. I l'app et continua dient qui ha de pagar a qui.
           </p>
         </div>
       </li>
@@ -1439,7 +1449,7 @@
           <h3 class="advantage-card__title">Portabilitat i sync reals</h3>
           <p class="advantage-card__desc">
             Pots moure grups entre dispositius amb importació, exportació o sync P2P xifrat,
-            sense convertir això en un sistema pesat ni obligar-te a registrar-te.
+            amb millor tolerància a grups grans i sense convertir això en un sistema pesat ni obligar-te a registrar-te.
           </p>
         </div>
       </div>
@@ -1550,7 +1560,7 @@
         <div class="faq-answer" id="faq-answer-7" role="region" aria-labelledby="faq-btn-7">
           Sí. Ara pots sincronitzar un grup directament entre dispositius amb una sessió
           P2P xifrada i una contrasenya compartida. Si prefereixes un flux més asíncron,
-          també pots compartir-lo amb un enllaç o fer servir exportació i importació.
+          també pots compartir-lo amb un enllaç, enviar recordatoris de pagament o fer servir exportació i importació.
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- add a PR preview workflow for the landing repo
- deploy previews to 
- comment on the PR with the preview URL and clean it up on close

## Why
Issue #20 asks for the same staging preview flow that already exists in , adapted to this static landing repository.

## Notes
- this repo is static, so the workflow deploys the site files directly instead of running an app build
- it reuses the same  repository and  secret pattern

Closes #20