### PR TITLE
marketing: align landing hero with issue #123 positioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
   <!-- SEO -->
-  <title>Reparteix – Despeses compartides amb sync privat i sense comptes</title>
-  <meta name="description" content="Reparteix és l'alternativa local-first a Splitwise. Gestiona despeses compartides, funciona offline, permet compartir recordatoris de pagament i sincronitza entre dispositius amb xifrat punt a punt, sense registre." />
+  <title>Reparteix – Despeses compartides sense comptes i sense complicacions</title>
+  <meta name="description" content="Per a viatges, pisos i grups. Reparteix funciona al moment, guarda les dades al teu dispositiu i et deixa sincronitzar-les en privat quan ho necessitis." />
   <link rel="canonical" href="https://reparteix.cat/" />
   <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
 
@@ -15,8 +15,8 @@
   <meta property="og:url" content="https://reparteix.cat/" />
   <meta property="og:site_name" content="Reparteix" />
   <meta property="og:locale" content="ca_ES" />
-  <meta property="og:title" content="Reparteix – Despeses compartides amb sync privat i sense comptes" />
-  <meta property="og:description" content="Alternativa local-first a Splitwise. Offline, privada, instal·lable, amb recordatoris compartibles i sincronització P2P xifrada." />
+  <meta property="og:title" content="Reparteix – Despeses compartides sense comptes i sense complicacions" />
+  <meta property="og:description" content="Per a viatges, pisos i grups. Reparteix funciona al moment, guarda les dades al teu dispositiu i et deixa sincronitzar-les en privat quan ho necessitis." />
   <meta property="og:image" content="https://reparteix.cat/og-image.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -24,8 +24,8 @@
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Reparteix – Despeses compartides amb sync privat i recordatoris" />
-  <meta name="twitter:description" content="Alternativa local-first a Splitwise. Offline, privada, instal·lable, amb recordatoris compartibles i sincronització P2P xifrada." />
+  <meta name="twitter:title" content="Reparteix – Despeses compartides sense comptes i sense complicacions" />
+  <meta name="twitter:description" content="Per a viatges, pisos i grups. Reparteix funciona al moment, guarda les dades al teu dispositiu i et deixa sincronitzar-les en privat quan ho necessitis." />
   <meta name="twitter:image" content="https://reparteix.cat/og-image.png" />
   <meta name="twitter:image:alt" content="Reparteix – App per gestionar despeses compartides" />
 
@@ -36,7 +36,7 @@
     "@type": "WebApplication",
     "name": "Reparteix",
     "url": "https://app.reparteix.cat/",
-    "description": "Reparteix és l'alternativa local-first a Splitwise. Gestiona despeses compartides, funciona offline, no requereix registre, permet compartir recordatoris de pagament i sincronització punt a punt xifrada entre dispositius.",
+    "description": "Reparteix ajuda a compartir despeses de grup sense comptes, amb les dades al teu dispositiu i sync privat quan el necessitis.",
     "applicationCategory": "FinanceApplication",
     "operatingSystem": "Any",
     "offers": {
@@ -1059,16 +1059,16 @@
     <div class="hero__inner">
       <div class="hero__content">
         <div class="hero__badge" aria-label="Destacat">
-          <span aria-hidden="true">✨</span> Alternativa simple a Splitwise
+          <span aria-hidden="true">✨</span> Sense comptes. Menys fricció. Més control.
         </div>
 
         <h1 class="hero__title">
-          Reparteix despeses compartides <em>amb sync privat, recordatoris i sense comptes</em>
+          Despeses compartides <em>sense comptes i sense complicacions</em>
         </h1>
 
         <p class="hero__subtitle">
-          Per a viatges, pisos i grups. Funciona offline, guarda les dades al teu dispositiu,
-          et deixa compartir recordatoris de pagament i sincronitza entre mòbils o ordinadors amb xifrat punt a punt.
+          Per a viatges, pisos i grups. Reparteix funciona al moment, guarda les dades al teu dispositiu
+          i et deixa sincronitzar-les en privat quan ho necessitis.
         </p>
 
         <div class="hero__ctas">
@@ -1086,7 +1086,7 @@
             <svg width="16" height="16" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
               <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
             </svg>
-            Gratuïta
+            Simple i immediata
           </div>
           <div class="hero__trust-item" role="listitem">
             <svg width="16" height="16" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
@@ -1098,13 +1098,13 @@
             <svg width="16" height="16" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
               <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
             </svg>
-            Funciona offline
+            Dades sota el teu control
           </div>
           <div class="hero__trust-item" role="listitem">
             <svg width="16" height="16" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
               <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
             </svg>
-            Sync P2P xifrat
+            Continuïtat entre dispositius
           </div>
         </div>
       </div>
@@ -1190,8 +1190,7 @@
           <li data-icon="✅">Tot clar i centralitzat: balanços en temps real</li>
           <li data-icon="✅">Obre l'app i comença a usar-la, sense registre</li>
           <li data-icon="✅">Les dades queden al teu dispositiu, sota el teu control</li>
-          <li data-icon="✅">Dades locals al teu dispositiu, amb còpies i importació fàcils</li>
-          <li data-icon="✅">Sync punt a punt xifrat entre dispositius, sense backend propi</li>
+          <li data-icon="✅">Pots continuar el grup en un altre dispositiu quan et calgui</li>
           <li data-icon="✅">Càlcul automàtic de transferències mínimes</li>
           <li data-icon="✅">Funciona sense connexió a internet</li>
         </ul>

--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
     "@type": "WebApplication",
     "name": "Reparteix",
     "url": "https://app.reparteix.cat/",
-    "description": "Reparteix ajuda a compartir despeses de grup sense comptes, amb les dades al teu dispositiu i sync privat quan el necessitis.",
+    "description": "Reparteix ajuda a compartir despeses de grup sense comptes, amb les dades al teu dispositiu i sincronització privada quan la necessitis.",
     "applicationCategory": "FinanceApplication",
     "operatingSystem": "Any",
     "offers": {

--- a/index.html
+++ b/index.html
@@ -983,6 +983,20 @@
         justify-content: center;
       }
 
+      .nav__mobile-menu .btn.btn-primary {
+        color: white;
+        background: var(--brand);
+        border-color: var(--brand);
+        box-shadow: 0 10px 24px rgba(63,58,168,.18);
+      }
+
+      .nav__mobile-menu .btn.btn-primary:hover,
+      .nav__mobile-menu .btn.btn-primary:focus-visible {
+        color: white;
+        background: var(--brand-dark);
+        border-color: var(--brand-dark);
+      }
+
       .hero { padding: 3.5rem 0 3rem; }
       .hero__inner { grid-template-columns: 1fr; gap: 2.5rem; }
       .hero__mockup { order: -1; }


### PR DESCRIPTION
Related to reparteix/reparteix#123

## Summary
- align SEO and social copy with the new positioning frame
- rework the landing hero around the approved narrative order: simple first, no account, control, continuity
- reduce top-of-page technical foregrounding in favor of product promise

## Validation
- reviewed resulting HTML diff locally