### PR TITLE
marketing: refine sync handoff copy on landing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1284,8 +1284,7 @@
         <div class="feature-card__icon" aria-hidden="true">🔐</div>
         <h3 class="feature-card__title">Sync P2P xifrat</h3>
         <p class="feature-card__desc">
-          Sincronitza un grup entre dos dispositius en temps real amb WebRTC i xifrat AES-GCM.
-          Sense compte, sense backend propi, amb contrasenya de grup i amb millor gestió de grups grans.
+          Continua un grup en un altre dispositiu amb un flux molt més simple: actives la sincronització, escaneges un QR o comparteixes un enllaç temporal i el grup se sincronitza en privat.
         </p>
       </article>
 
@@ -1293,8 +1292,8 @@
         <div class="feature-card__icon" aria-hidden="true">🔗</div>
         <h3 class="feature-card__title">Compartir per enllaç</h3>
         <p class="feature-card__desc">
-          Pots enviar un enllaç de sync perquè l'altra persona s'uneixi en un clic,
-          o bé compartir snapshots/importacions quan et vagi millor.
+          Genera un enllaç temporal perquè l'altre dispositiu entri directament al grup,
+          o fes servir el QR si tens els dos dispositius a mà.
         </p>
       </article>
 
@@ -1338,7 +1337,7 @@
       <div class="section-label">Com funciona</div>
       <h2 class="section-title" id="com-funciona-title">Liquidat en 3 passos</h2>
       <p class="section-subtitle">
-        Crea el grup, apunta despeses i sincronitza'l quan calgui. Tot sense compte i mantenint el control de les dades.
+        Crea el grup, apunta despeses i continua'l en un altre dispositiu quan calgui. Tot sense compte i mantenint el control de les dades.
       </p>
     </div>
 
@@ -1370,8 +1369,7 @@
         <div>
           <h3 class="step__title">Sincronitza o liquida</h3>
           <p class="step__desc">
-            Quan vulguis continuar en un altre dispositiu o compartir l'estat del grup,
-            fas un sync xifrat o comparteixes un recordatori de pagament. I l'app et continua dient qui ha de pagar a qui.
+            Quan vulguis continuar en un altre dispositiu, actives la sincronització, escaneges el QR o comparteixes un enllaç temporal. I l'app et continua dient qui ha de pagar a qui.
           </p>
         </div>
       </li>
@@ -1571,9 +1569,7 @@
           <span class="faq-question__icon" aria-hidden="true">+</span>
         </button>
         <div class="faq-answer" id="faq-answer-7" role="region" aria-labelledby="faq-btn-7">
-          Sí. Ara pots sincronitzar un grup directament entre dispositius amb una sessió
-          P2P xifrada i una contrasenya compartida. Si prefereixes un flux més asíncron,
-          també pots compartir-lo amb un enllaç, enviar recordatoris de pagament o fer servir exportació i importació.
+          Sí. Pots continuar un grup en un altre dispositiu amb un QR o un enllaç temporal dins d'una sessió privada i xifrada amb contrasenya de grup. Si prefereixes un flux més asíncron, també pots exportar i importar les dades.
         </div>
       </div>
 


### PR DESCRIPTION
## Què canvia
- alinea la landing amb el nou flux de sync/share per continuar un grup en un altre dispositiu
- reforça el missatge de QR + enllaç temporal com a handoff principal
- simplifica el llenguatge de sync perquè sigui més tangible i menys tècnic

## Validació
- revisió manual del copy a `index.html`

## Context
- reflecteix millor el treball recent fet al producte sobre el flux de compartir i sincronitzar grups
